### PR TITLE
Fixed import to also work on Python 3.11

### DIFF
--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -2,7 +2,13 @@
 # inputs of the OpenTherm component.
 
 from typing import Dict, Generic, Tuple, TypeVar, TypedDict
-from typing_extensions import NotRequired
+
+# NotRequired was moved to typing in Python 3.11
+# as long as ESPHome supports Python < 3.11, we need to allow both imports
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
 
 from esphome.const import (
     UNIT_CELSIUS,


### PR DESCRIPTION
As the code comment says, ESPHome add-on moved to Python 3.11 for 2023.11, this breaks the component, as the NotRequired import was moved from the typing_extensions to the typing package.

This should fix it for both versions (I tested compiling on both 3.11.4, 3.9.17, and using the ESPHome add-on in HASS)