### PR TITLE
Changed the PID to temperature calculation. 

### DIFF
--- a/components/opentherm/output.h
+++ b/components/opentherm/output.h
@@ -19,7 +19,7 @@ public:
     void set_id(const char* id) { this->id = id; }
 
     void write_state(float state) override {
-        this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(state * 100, min_value, max_value);
+        this->state = state < 0.003 && this->zero_means_zero_ ? 0.0 : clamp(state * (max_value - min_value) + min_value, min_value, max_value);
         this->has_state_ = true;
         ESP_LOGD("opentherm.output", "Output set to %.2f", this->state);
     };


### PR DESCRIPTION
On a boiler that has a min flow temp of 50C and a max of 70C set the pid output would be clipped, a pid output of 100% would be 70C as you expect, but a pid output of 70% is the same as 100% ie 70C. The same goes for minimum flow temp, 1% to 50% pid output produces a flow temp of 50C.

This is problematic for PID tuning, producing results which dont work. It also causes bigger jumps in temperature when PID is modulating in the 50-70% range, a large drop in requested temperature will result in the boiler shutting off instead of modulating down. Since I implemented the change on my system I'm seeing more stable temperature regulation, much less target temperature overshoot, and much less boiler cycling on and off, which is how an opentherm system should work. Setting output_averaging_samples helps to smooth the boiler setpoint, I am currently using 2.

My system is an Intergas 18kw system boiler with 14 radiators in a poorly insulated Victorian home built in 1898 for reference. The outside temperature while testing has been in the range -4 to 2C, inside room setpoint 20.8C

The code on that line could be better, clamp() is not needed. I made the minimum changes to get the effect and I am not strong at coding. sorry.