### PR TITLE
Add sm_active and dhw_block Switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ The following switches are available:
   Defaults to *False*
 - `ch2_active`: Central Heating 2 active
   Defaults to *False*
+- `sm_active`: Summer mode active
+  Defaults to *False*
+- `dhw_block`: Force block Domestic Hot Water
+  Defaults to *False*
 <!-- END schema_docs:switch -->
 
 ### Binary sensor

--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -125,22 +125,37 @@ unsigned int OpenthermHub::build_request(OpenThermMessageID request_id) {
                 true
             #endif
             ;
-        bool ch2_active = 
+        bool ch2_active =
             this->ch2_active
-            && 
+            &&
             #ifdef OPENTHERM_READ_ch2_active
                 OPENTHERM_READ_ch2_active
             #else
                 true
-            #endif 
-            && 
+            #endif
+            &&
             #ifdef OPENTHERM_READ_t_set_ch2
                 OPENTHERM_READ_t_set_ch2 > 0.0
             #else
                 true
             #endif
             ;
-        return ot->buildSetBoilerStatusRequest(ch_enable, dhw_enable, cooling_enable, otc_active, ch2_active);
+        bool sm_active =
+            #ifdef OPENTHERM_READ_sm_active
+                OPENTHERM_READ_sm_active
+            #else
+                false
+            #endif
+            ;
+        bool dhw_block =
+            #ifdef OPENTHERM_READ_dhw_block
+                OPENTHERM_READ_dhw_block
+            #else
+                false
+            #endif
+            ;
+        ESP_LOGD(TAG, "Building sm active: %d - DHW Block: %d", sm_active, dhw_block);
+        return ot->buildSetBoilerStatusRequest(ch_enable, dhw_enable, cooling_enable, otc_active, ch2_active,sm_active, dhw_block);
     }
 
     // Next, we start with the write requests from switches and other inputs,

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -654,6 +654,20 @@ SWITCHES: Schema[SwitchSchema] = Schema({
         "message_data": "flag8_hb_4",
         "default_mode": "restore_default_off"
     }),
+    "sm_active": SwitchSchema({
+        "description": "Summer mode active",
+        "message": "Status",
+        "keep_updated": True,
+        "message_data": "flag8_hb_5",
+        "default_mode": "restore_default_off"
+    }),
+    "dhw_block": SwitchSchema({
+        "description": "DHW Blocking",
+        "message": "Status",
+        "keep_updated": True,
+        "message_data": "flag8_hb_6",
+        "default_mode": "restore_default_off"
+    }),
 })
 
 class AutoConfigure(TypedDict):


### PR DESCRIPTION
Hi,
I've added two switches to your opentherm component:
- sm_active (Summer Mode)
- dhw_block (Domestic hot Water blocking

These switches are needed for some (for example mine :) ) boilers to correctly handle central heating and domestic hot water on/off functions.

Please note it's needed an updated version of Opentherm Library (See my other pull request at https://github.com/FreeBear-nc/opentherm_library/pull/1 )

PS I've updated the documentation too including the new switches